### PR TITLE
Internal Rate of Return, NPV takes an array

### DIFF
--- a/lib/ROQTI/Investment_decision_criteria.rb
+++ b/lib/ROQTI/Investment_decision_criteria.rb
@@ -10,10 +10,39 @@ class InvestmentDecisionCriteria
 
   def self.net_present_value(initial_investment, number_of_periods, interest_rate, cash_flow )
     npv = -initial_investment.to_f
-    counter = (1..number_of_periods).inject { |t, sum|
-      sum + cash_flow.to_f/ ( (1 + interest_rate) ** t )}
-    return  npv + counter
+    sum = 0
+    if cash_flow.length != number_of_periods
+      for t in (0..number_of_periods-1).to_a
+          sum += cash_flow[0].to_f/((1 + interest_rate) ** (t+1) )
+      end
+    else #it's a well-formed list of yearly cashflows
+      for t in (0..number_of_periods-1).to_a
+          sum += cash_flow[t].to_f/((1 + interest_rate) ** (t+1) )
+      end
+    end
+    return  npv + sum
 
+  end
+
+  def self.internal_rate_of_return(initial_investment, number_of_periods, cash_flow)
+    # "The IRR is the solution rate r to the equation NPV(r) = 0
+    interest_rate = 1.0
+    npv = net_present_value(initial_investment, number_of_periods, interest_rate, cash_flow)
+    converging = true
+    while converging
+      new_rate = interest_rate - 0.01
+      #puts "Interest Rate: #{new_rate}"
+      new_npv = net_present_value(initial_investment, number_of_periods, new_rate, cash_flow)
+      #puts "NPV: #{new_npv}"
+      if new_npv.abs < npv.abs && new_rate >= 0.0 
+        #npv must approach zero
+        interest_rate = new_rate
+        npv = new_npv
+      else
+        converging = false
+      end
+    end
+    return interest_rate
   end
 
 end
@@ -22,4 +51,6 @@ puts InvestmentDecisionCriteria.rate_of_return(100, 117, 5)
 puts InvestmentDecisionCriteria.rate_of_return(90, 105)
 puts InvestmentDecisionCriteria.time_of_return(90, 105)
 
-puts InvestmentDecisionCriteria.net_present_value(10, 4, 0.04, 1)
+puts InvestmentDecisionCriteria.net_present_value(10, 4, 0.04, [1])
+puts InvestmentDecisionCriteria.net_present_value(400, 4, 0.1, [100, -150, 200, 500])
+puts InvestmentDecisionCriteria.internal_rate_of_return(400, 4, [100, -150, 200, 500])

--- a/lib/ROQTI/interest_rates.rb
+++ b/lib/ROQTI/interest_rates.rb
@@ -15,6 +15,8 @@ class InterestRates
   def self.present_value(amount_paid, periods, interest_rate)
     return amount_paid.to_f / (1 + interest_rate) ** periods
   end
+
+
 end
 
 
@@ -23,3 +25,4 @@ puts InterestRates.gross_interest_rate(75, 20)
 puts InterestRates.basic_compound_interest_rate(2000, 0.10, 2)
 puts InterestRates.effective_compound_interest_rate(0.05, 6)
 puts InterestRates.present_value(1000000, 0.25, 0.05)
+


### PR DESCRIPTION
Internal Rate of Return returns expected results, though only to 1 percentage point. Changed NPV to accept array of cash flows; if array is not the expected length, just uses element 0 (use this to pass in a static cash flow as a 1-element list).
